### PR TITLE
Fixing time to end of production

### DIFF
--- a/battery_predict.yaml
+++ b/battery_predict.yaml
@@ -48,7 +48,7 @@ template:
       - name: PV Zeit zu Ende Produktion
         #friendly_name: PV time till end of production
         unit_of_measurement: h
-        state: "{% set endProd = ((((((state_attr('sun.sun', 'next_setting')| as_timestamp - (40*60))|as_datetime|as_local) - now()).seconds / 60) |int(0))/60)  | round(2)| float(0)%} {{endProd| float(0)}}"
+        state: "{% if 'above_horizon' in states('sun.sun') %} {% set endProd = ((((((state_attr('sun.sun', 'next_setting')| as_timestamp - (40*60))|as_datetime|as_local) - now()).seconds / 60) |int(0))/60)  | round(2)| float(0)%} {% else%} {% set endProd = 0 | float(0) %} {%endif%} {{endProd| float(0)}}"
       #Secondary Calculations
       - name: PV Verbrauch bis Sonnenaufgang
         #friendly_name: PV power used till sunrise


### PR DESCRIPTION
Checking if sun is up to calculate time to next sunset, else we set it to zero directly, so that battery charge time works correctly.